### PR TITLE
Enabled AI Mutli-Cam

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -86,7 +86,7 @@
 	var/datum/action/innate/deploy_last_shell/redeploy_action = new
 	var/chnotify = 0
 
-	var/multicam_allowed = FALSE
+	var/multicam_allowed = TRUE
 	var/multicam_on = FALSE
 	var/obj/screen/movable/pic_in_pic/ai/master_multicam
 	var/list/multicam_screens = list()


### PR DESCRIPTION
COMPUTERMAN SAY "WYCI"
SO ME "CI"

Allows AI to use the Multi-Cam function, letting them view 6 static locations on a screen. While viewing these they cannot use their normal, active, camera, and the 6 areas will have all of their cameras turn red on the lens. (Normally green.)

Said Multicams cannot track people and only view static locations.

All I did was enable it because I find it immersive and cool. Obviously buffs AI, but the multicams aren't visible unless he's looking at them.